### PR TITLE
Disable TLS 1.0

### DIFF
--- a/compose-assets/docker-compose.yml
+++ b/compose-assets/docker-compose.yml
@@ -16,7 +16,7 @@ services:
       - --entryPoints=Name:http Address::80 Compress::true
       - --defaultEntryPoints=http
       # - --entrypoints=Name:http Address::80 Redirect.EntryPoint:https Compress::true
-      # - --entryPoints=Name:https Address::443 TLS:/ssl/ssl.crt,/ssl/ssl.key Compress::true
+      # - --entryPoints=Name:https Address::443 TLS:/ssl/ssl.crt,/ssl/ssl.key TLS TLS.MinVersion:VersionTLS11 TLS.CipherSuites:TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256
       # - --defaultentrypoints=http,https
 
     volumes:

--- a/compose-assets/docker-compose.yml
+++ b/compose-assets/docker-compose.yml
@@ -16,7 +16,7 @@ services:
       - --entryPoints=Name:http Address::80 Compress::true
       - --defaultEntryPoints=http
       # - --entrypoints=Name:http Address::80 Redirect.EntryPoint:https Compress::true
-      # - --entryPoints=Name:https Address::443 TLS:/ssl/ssl.crt,/ssl/ssl.key Compress::true TLS TLS.MinVersion:VersionTLS11 TLS.CipherSuites:TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256
+      # - --entryPoints=Name:https Address::443 TLS:/ssl/ssl.crt,/ssl/ssl.key Compress::true TLS TLS.MinVersion:VersionTLS12 TLS.CipherSuites:TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256
       # - --defaultentrypoints=http,https
 
     volumes:

--- a/compose-assets/docker-compose.yml
+++ b/compose-assets/docker-compose.yml
@@ -16,7 +16,7 @@ services:
       - --entryPoints=Name:http Address::80 Compress::true
       - --defaultEntryPoints=http
       # - --entrypoints=Name:http Address::80 Redirect.EntryPoint:https Compress::true
-      # - --entryPoints=Name:https Address::443 TLS:/ssl/ssl.crt,/ssl/ssl.key TLS TLS.MinVersion:VersionTLS11 TLS.CipherSuites:TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256
+      # - --entryPoints=Name:https Address::443 TLS:/ssl/ssl.crt,/ssl/ssl.key Compress::true TLS TLS.MinVersion:VersionTLS11 TLS.CipherSuites:TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256
       # - --defaultentrypoints=http,https
 
     volumes:


### PR DESCRIPTION
Currently we support TLS versions that are outdated and are a possible security risk:
![image](https://user-images.githubusercontent.com/1486681/87364811-77a73800-c529-11ea-8365-ce8b7fcf476c.png)

This PR sets a minimum version of TLS and improves our TLS handling:
![image](https://user-images.githubusercontent.com/1486681/87364897-a3c2b900-c529-11ea-89c5-17e928b8bd2a.png)

source:
https://www.ssllabs.com/ssltest/analyze.html?d=cce-pt-1.codecov.dev