### PR TITLE
Add POC docker-compose

### DIFF
--- a/compose-assets/proof_of_concept/codecov.yml
+++ b/compose-assets/proof_of_concept/codecov.yml
@@ -1,0 +1,22 @@
+setup:
+  # Replace with the http location of your Codecov. Remove any trailing slashes (e.g., "https://my.codecov.com" instead of "https://my.codecov.com/")
+  # https://docs.codecov.io/docs/configuration#section-codecov-url
+  codecov_url: null
+  # Replace with your Codecov Enterprise License key
+  # https://docs.codecov.io/docs/configuration#section-enterprise-license
+  enterprise_license: null
+  # Replace with a random string
+  # https://docs.codecov.io/docs/configuration#section-cookie-secret
+  http:
+    cookie_secret: null
+services:
+  database_url: "postgres://{USER}:{PASSWORD}@{HOST}:{PORT}/{DB_NAME}"
+  postgres_url: "redis_url: redis://{USER}:{PASSWORD}@{HOST}:{PORT}/{DB_NAME}"
+  minio: # S3 configuration is below. For GCS configuration, see: https://docs.codecov.io/changelog/release-notes-for-codecov-v448#you-deploy-using-docker-compose-on-one-or-many-virtual-machines-but-your-minio-server-is-backed-by-s3-or-google-cloud-storage
+    host: s3.amazonaws.com
+    bucket: <bucket-name>
+    region: <bucket-region>
+    verify_ssl: true
+    access_key_id: <aws-iam-access-key> #only required if you're not using AWS IAM Roles for S3
+    secret_access_key: <aws-iam-secret> #only required if you're not using AWS IAM Roles for S3
+

--- a/compose-assets/proof_of_concept/codecov.yml
+++ b/compose-assets/proof_of_concept/codecov.yml
@@ -14,7 +14,7 @@ github_enterprise: #for other repo providers see: https://docs.codecov.io/docs/s
   client_secret: <your-oauth-app-client-secret>
 services:
   database_url: "postgres://{USER}:{PASSWORD}@{HOST}:{PORT}/{DB_NAME}"
-  postgres_url: "redis_url: redis://{USER}:{PASSWORD}@{HOST}:{PORT}/{DB_NAME}"
+  postgres_url: "redis://{USER}:{PASSWORD}@{HOST}:{PORT}/{DB_NAME}"
   minio: # S3 configuration is below. For GCS configuration, see: https://docs.codecov.io/changelog/release-notes-for-codecov-v448#you-deploy-using-docker-compose-on-one-or-many-virtual-machines-but-your-minio-server-is-backed-by-s3-or-google-cloud-storage
     host: s3.amazonaws.com
     bucket: <bucket-name>

--- a/compose-assets/proof_of_concept/codecov.yml
+++ b/compose-assets/proof_of_concept/codecov.yml
@@ -9,6 +9,9 @@ setup:
   # https://docs.codecov.io/docs/configuration#section-cookie-secret
   http:
     cookie_secret: null
+github_enterprise: #for other repo providers see: https://docs.codecov.io/docs/set-up-oauth-login
+  client_id: <your-oauth-app-client-id>
+  client_secret: <your-oauth-app-client-secret>
 services:
   database_url: "postgres://{USER}:{PASSWORD}@{HOST}:{PORT}/{DB_NAME}"
   postgres_url: "redis_url: redis://{USER}:{PASSWORD}@{HOST}:{PORT}/{DB_NAME}"

--- a/compose-assets/proof_of_concept/codecov.yml
+++ b/compose-assets/proof_of_concept/codecov.yml
@@ -14,7 +14,7 @@ github_enterprise: #for other repo providers see: https://docs.codecov.io/docs/s
   client_secret: <your-oauth-app-client-secret>
 services:
   database_url: "postgres://{USER}:{PASSWORD}@{HOST}:{PORT}/{DB_NAME}"
-  postgres_url: "redis://{USER}:{PASSWORD}@{HOST}:{PORT}/{DB_NAME}"
+  redis_url: "redis://{USER}:{PASSWORD}@{HOST}:{PORT}/{DB_NAME}"
   minio: # S3 configuration is below. For GCS configuration, see: https://docs.codecov.io/changelog/release-notes-for-codecov-v448#you-deploy-using-docker-compose-on-one-or-many-virtual-machines-but-your-minio-server-is-backed-by-s3-or-google-cloud-storage
     host: s3.amazonaws.com
     bucket: <bucket-name>

--- a/compose-assets/proof_of_concept/docker-compose.yml
+++ b/compose-assets/proof_of_concept/docker-compose.yml
@@ -16,7 +16,7 @@ services:
       - --entryPoints=Name:http Address::80 Compress::true
       - --defaultEntryPoints=http
       # - --entrypoints=Name:http Address::80 Redirect.EntryPoint:https Compress::true
-      # - --entryPoints=Name:https Address::443 TLS:/ssl/ssl.crt,/ssl/ssl.key Compress::true
+      # - --entryPoints=Name:https Address::443 TLS:/ssl/ssl.crt,/ssl/ssl.key Compress::true TLS TLS.MinVersion:VersionTLS12 TLS.CipherSuites:TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256
       # - --defaultentrypoints=http,https
 
     volumes:
@@ -33,10 +33,11 @@ services:
     depends_on:
       - web
   web:
-    image: codecov/enterprise:v4.4.10
+    image: codecov/enterprise-web:latest-stable
     command: web
     volumes:
       - ./codecov.yml:/config/codecov.yml:ro
+      - archive-volume:/archive
     ports:
       - "5000"
     labels:
@@ -54,13 +55,17 @@ services:
       - statsd
 
   worker:
-    image: codecov/enterprise:v4.4.10
+    image: codecov/enterprise-worker:latest-stable
     command: worker
     volumes:
       - ./codecov.yml:/config/codecov.yml:ro
+      - ./config:/config
+      - archive-volume:/archive
     environment:
       - STATSD_HOST=statsd
       - DATADOG_TRACE_ENABLED=false
+      - CELERY_BROKER_URL=redis://redis:6379/0
+      - CELERY_RESULT_BACKEND=redis://redis:6379/0
     networks:
       - codecov
     depends_on:

--- a/compose-assets/proof_of_concept/docker-compose.yml
+++ b/compose-assets/proof_of_concept/docker-compose.yml
@@ -33,7 +33,7 @@ services:
     depends_on:
       - web
   web:
-    image: codecov/enterprise-web:latest-stable
+    image: codecov/enterprise-web:latest-stable #note: this is for setup purposes only, be sure to pin to the latest release from our changelog: https://docs.codecov.io/changelog
     command: web
     volumes:
       - ./codecov.yml:/config/codecov.yml:ro
@@ -55,7 +55,7 @@ services:
       - statsd
 
   worker:
-    image: codecov/enterprise-worker:latest-stable
+    image: codecov/enterprise-worker:latest-stable #note: this is for setup purposes only, be sure to pin to the latest release from our changelog: https://docs.codecov.io/changelog
     command: worker
     volumes:
       - ./codecov.yml:/config/codecov.yml:ro

--- a/compose-assets/proof_of_concept/docker-compose.yml
+++ b/compose-assets/proof_of_concept/docker-compose.yml
@@ -1,0 +1,81 @@
+version: "3"
+
+services:
+  traefik:
+    image: traefik:v1.7-alpine
+    # NOTE: quotes do not work in these commands
+    command:
+      - --api
+      - --docker
+      - --docker.watch
+      - --docker.constraints=tag==web
+      - --metrics
+      - --metrics.prometheus
+
+      # NOTE: Toggle the lines below to enable SSL
+      - --entryPoints=Name:http Address::80 Compress::true
+      - --defaultEntryPoints=http
+      # - --entrypoints=Name:http Address::80 Redirect.EntryPoint:https Compress::true
+      # - --entryPoints=Name:https Address::443 TLS:/ssl/ssl.crt,/ssl/ssl.key Compress::true
+      # - --defaultentrypoints=http,https
+
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:rw
+      - /dev/null:/traefik.toml:rw
+      # NOTE: Provide the SSL certs in the ./config folder below
+      # - ./config:/ssl
+    ports:
+      - "80:80"
+      - "8080:8080"
+      - "443:443"
+    networks:
+      - codecov
+    depends_on:
+      - web
+  web:
+    image: codecov/enterprise:v4.4.10
+    command: web
+    volumes:
+      - ./codecov.yml:/config/codecov.yml:ro
+    ports:
+      - "5000"
+    labels:
+      - "traefik.tags=web"
+      - "traefik.backend=web"
+      - "traefik.port=5000"
+      - "traefik.frontend.rule=PathPrefix: /"
+    environment:
+      - STATSD_HOST=statsd
+      - DATADOG_TRACE_ENABLED=false
+    networks:
+      - codecov
+    depends_on:
+      - minio
+      - statsd
+
+  worker:
+    image: codecov/enterprise:v4.4.10
+    command: worker
+    volumes:
+      - ./codecov.yml:/config/codecov.yml:ro
+    environment:
+      - STATSD_HOST=statsd
+      - DATADOG_TRACE_ENABLED=false
+    networks:
+      - codecov
+    depends_on:
+      - minio
+      - statsd
+
+  statsd:
+    image: prom/statsd-exporter:v0.6.0
+    command: -statsd.listen-udp=:8125 -statsd.listen-tcp=:8125
+    ports:
+      - "8125"
+      - "9102"
+    networks:
+      - codecov
+
+networks:
+  codecov:
+    driver: bridge


### PR DESCRIPTION
adds a poc file for lightweight docker-compose based installations that want persistent data.