### PR TITLE
Specify redis_url

### DIFF
--- a/general/codecov.yml
+++ b/general/codecov.yml
@@ -12,6 +12,7 @@ setup:
   http:
     cookie_secret: null
 services:
+  redis_url: "redis://redis:6379"
   minio:
     client_uploads: true
     host: minio

--- a/metrics/codecov.yml
+++ b/metrics/codecov.yml
@@ -12,6 +12,7 @@ setup:
   http:
     cookie_secret: null
 services:
+  redis_url: "redis://redis:6379"
   minio:
     client_uploads: true
     host: minio

--- a/sample.codecov.yml
+++ b/sample.codecov.yml
@@ -16,7 +16,7 @@ setup:
 
 services:
   database_url: null            # (required) postgres url [may leave empty for when using Docker]
-  redis_url: null               # (required) used for celery and storing reports before processing [may leave empty for when using Docker]
+  redis_url: null               # (required) used for celery and storing reports before processing
   rabbitmq_url: null            # specify to use a rabbitmq as the celery broker
   google_analytics_key: null    # front-end tracking
   ci_providers: null            # list of ci domains to check GitHub Status target urls against, ex: "- jenkins.my-company.com"


### PR DESCRIPTION
Avoiding potential redis issue with library by specifying the redis_url in docker environments.